### PR TITLE
CI: upgrade to checkout@v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Create output directory # TODO: Remove after https://github.com/ForNeVeR/ChangelogAutomation/issues/10
         shell: pwsh


### PR DESCRIPTION
Should clear all the CI warnings.